### PR TITLE
Removing Template Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Get facts about a Linux system. Parallel execution, structured output, remote AP
 
 ## Install
 
-```
-wget https://github.com/kelseyhightower/terminus/releases/download/v0.0.1/terminus
-chmod +x terminus
+```shell
+$ wget https://github.com/jtopjian/terminus/releases/download/v0.0.3/terminus.gz
+$ gzip -d terminus.gz
+$ chmod +x terminus
 ```
 
 ## Usage
@@ -15,24 +16,15 @@ Terminus ships with a default set of facts that represent info about the system.
 
 ### Print a single fact
 
-```
-$ terminus --format '{{.System.BootID}}'
-029b978a8d0b4ac48c5ca9c92956eeb6
-```
-
-or
-
-```
+```shell
 $ terminus System.Network.Interfaces.eth0.Ip6Addresses.0.Ip
 fe80::f816:3eff:fead:8549
 ```
 
 ### Print all facts
 
-```
-terminus
-```
-```
+```shell
+$ terminus
 {
    "System": {
      "Architecture": "x86_64",

--- a/docs/custom-facts.md
+++ b/docs/custom-facts.md
@@ -8,7 +8,7 @@ Executable facts can be written in any language and reside under the external fa
 
 ### Example
 
-```
+```shell
 sudo vim /etc/terminus/facts.d/date
 ```
 
@@ -19,15 +19,9 @@ echo "{\"Now\": \"$(date)\"}"
 exit 0
 ```
 
-```
-sudo chmod +x /etc/terminus/facts.d/date
-```
-
-```
-terminus -format '{{.date.Now}}'
-```
-
-```
+```shell
+$ sudo chmod +x /etc/terminus/facts.d/date
+$ terminus date
 Sat Apr 11 13:38:26 PDT 2015
 ```
 
@@ -37,11 +31,11 @@ Static facts must be in the JSON format and reside under the external facts dire
 
 ### Example
 
-```
-sudo vim /etc/terminus/facts.d/docker.json
+```shell
+$ sudo vim /etc/terminus/facts.d/docker.json
 ```
 
-```
+```json
 {
   "ClientAPIVersion": "1.16",
   "ClientOSArch": "linux/amd64",
@@ -52,10 +46,7 @@ sudo vim /etc/terminus/facts.d/docker.json
 }
 ```
 
-```
-terminus -format '{{.docker.ServerAPIVersion}}'
-```
-
-```
+```shell
+$ terminus docker.ServerAPIVersion
 1.16
 ```

--- a/main.go
+++ b/main.go
@@ -12,13 +12,10 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"text/template"
 )
 
 var (
 	externalFactsDir string
-	format           string
-	formatFile       string
 	httpAddr         string
 	printVersion     bool
 	debug            bool
@@ -27,8 +24,6 @@ var (
 func init() {
 	log.SetFlags(0)
 	flag.StringVar(&externalFactsDir, "external-facts-dir", defaultExternalFacts, "Path to external facts directory.")
-	flag.StringVar(&format, "format", "", "Format the output using the given go template.")
-	flag.StringVar(&formatFile, "format-file", "", "Format the output using the given go template file.")
 	flag.StringVar(&httpAddr, "http", "", "HTTP service address (e.g., ':6060')")
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
 	flag.BoolVar(&debug, "debug", false, "print errors to stderr instead of ignoring them")
@@ -50,30 +45,6 @@ func main() {
 	}
 
 	f := getFacts()
-
-	if format != "" {
-		tmpl, err := template.New("format").Parse(format)
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = tmpl.Execute(os.Stdout, &f.Facts)
-		if err != nil {
-			log.Fatal(err)
-		}
-		os.Exit(0)
-	}
-
-	if formatFile != "" {
-		tmpl, err := template.ParseFiles(formatFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = tmpl.Execute(os.Stdout, &f.Facts)
-		if err != nil {
-			log.Fatal(err)
-		}
-		os.Exit(0)
-	}
 
 	// If there are arguments left over, use the first argument as a fact query.
 	if len(flag.Args()) > 0 {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.0.2"
+const Version = "0.0.4-dev"


### PR DESCRIPTION
This commit removes the ability to specify the output as a golang text
template. My opinion is that it provides a difficult user experience.

The HTTP API feature has been untouched for now.
